### PR TITLE
Fixed README.md wrong instructions (cd to wrong path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ```
 git clone https://github.com/Khanmanan/automod-bot.git
-cd discord-js-bot
+cd automod-bot
 npm install
 ```
 


### PR DESCRIPTION
When trying to clone and deploy from source, I got a problem of cd'ing the wrong folder, written in the README.md. This is a very simple pull request to fix the README.md with the right path (automod-bot instead of discord-js-bot).